### PR TITLE
FO-1901 Fjernet endepunkt for å finne navn til enhet

### DIFF
--- a/src/main/java/no/nav/fo/provider/rest/EnhetController.java
+++ b/src/main/java/no/nav/fo/provider/rest/EnhetController.java
@@ -2,8 +2,6 @@ package no.nav.fo.provider.rest;
 
 
 import io.swagger.annotations.Api;
-import no.nav.fo.PortefoljeEnhet;
-import no.nav.fo.service.OrganisasjonEnhetV2Service;
 import no.nav.fo.service.VirksomhetEnhetService;
 import no.nav.sbl.dialogarena.common.abac.pep.Pep;
 import no.nav.virksomhet.tjenester.enhet.v1.HentRessursListeEnhetikkefunnet;
@@ -15,8 +13,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-
-import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
@@ -30,27 +26,7 @@ public class EnhetController {
     private VirksomhetEnhetService virksomhetEnhetService;
 
     @Inject
-    private OrganisasjonEnhetV2Service organisasjonEnhetV2Service;
-
-    @Inject
     private Pep pepClient;
-
-    @GET
-    @Path("/{enhetId}/navn")
-    public Response hentNavn(@PathParam("enhetId") String enhetId) {
-        try {
-            final PortefoljeEnhet portefoljeEnhet = organisasjonEnhetV2Service.hentAlleEnheter()
-                    .stream()
-                    .filter((enhet) -> enhet.getEnhetId().equals(enhetId))
-                    .findFirst().orElseThrow(HentRessursListeEnhetikkefunnet::new);
-
-            return Response.ok().entity(portefoljeEnhet).build();
-        } catch (HentRessursListeEnhetikkefunnet e) {
-            return Response.status(NO_CONTENT).build();
-        } catch (Exception e) {
-            return Response.status(INTERNAL_SERVER_ERROR).build();
-        }
-    }
 
     @GET
     @Path("/{enhetId}/veiledere")


### PR DESCRIPTION
Funksjonaliteten til dette endepunktet har blitt integrert inn i veilarbregistrering, slik at det ikke lenger trengs på veilarbveileder.