### PR TITLE
Bruk egen ABAC instanse for å gjøre spørringer på "modia"-domenet

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -57,3 +57,5 @@ spec:
       value: ldaps://ldapgw.preprod.local
     - name: LDAP_DOMAIN
       value: PREPROD.LOCAL
+    - name: ABAC_MODIA_URL
+      value: https://abac-modia.dev.intern.nav.no/application/asm-pdp/authorize

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -55,3 +55,5 @@ spec:
       value: ldaps://ldapgw.adeo.no
     - name: LDAP_DOMAIN
       value: ADEO.NO
+    - name: ABAC_MODIA_URL
+      value: https://abac-modia.intern.nav.no/application/asm-pdp/authorize

--- a/src/main/java/no/nav/veilarbveileder/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/veilarbveileder/config/ApplicationConfig.java
@@ -1,7 +1,7 @@
 package no.nav.veilarbveileder.config;
 
 import lombok.extern.slf4j.Slf4j;
-import no.nav.common.abac.Pep;
+import no.nav.common.abac.VeilarbPep;
 import no.nav.common.abac.VeilarbPepFactory;
 import no.nav.common.abac.audit.SpringAuditRequestInfoSupplier;
 import no.nav.common.auth.context.AuthContextHolder;
@@ -25,6 +25,7 @@ import no.nav.common.utils.UrlUtils;
 import no.nav.veilarbveileder.client.LdapClient;
 import no.nav.veilarbveileder.client.LdapClientImpl;
 import no.nav.veilarbveileder.utils.DevNomClient;
+import no.nav.veilarbveileder.utils.ModiaPep;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,11 +60,21 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public Pep pep(EnvironmentProperties properties, Credentials serviceUserCredentials) {
+    public VeilarbPep veilarbPep(EnvironmentProperties properties, Credentials serviceUserCredentials) {
         return VeilarbPepFactory.get(
-                properties.getAbacUrl(), serviceUserCredentials.username,
+                properties.getAbacVeilarbUrl(), serviceUserCredentials.username,
                 serviceUserCredentials.password, new SpringAuditRequestInfoSupplier()
         );
+    }
+
+    @Bean
+    public ModiaPep modiaPep(EnvironmentProperties properties, Credentials serviceUserCredentials) {
+        var pep = VeilarbPepFactory.get(
+                properties.getAbacModiaUrl(), serviceUserCredentials.username,
+                serviceUserCredentials.password, new SpringAuditRequestInfoSupplier()
+        );
+
+        return new ModiaPep(pep);
     }
 
     @Bean

--- a/src/main/java/no/nav/veilarbveileder/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/veilarbveileder/config/EnvironmentProperties.java
@@ -21,7 +21,9 @@ public class EnvironmentProperties {
 
     private String naisStsDiscoveryUrl;
 
-    private String abacUrl;
+    private String abacVeilarbUrl;
+
+    private String abacModiaUrl;
 
     private String norg2Url;
 

--- a/src/main/java/no/nav/veilarbveileder/service/AuthService.java
+++ b/src/main/java/no/nav/veilarbveileder/service/AuthService.java
@@ -2,11 +2,12 @@ package no.nav.veilarbveileder.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.common.abac.Pep;
+import no.nav.common.abac.VeilarbPep;
 import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.types.identer.EnhetId;
 import no.nav.common.types.identer.NavIdent;
 import no.nav.veilarbveileder.client.LdapClient;
+import no.nav.veilarbveileder.utils.ModiaPep;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -18,7 +19,9 @@ public class AuthService {
 
     private final AuthContextHolder authContextHolder;
 
-    private final Pep veilarbPep;
+    private final VeilarbPep veilarbPep;
+
+    private final ModiaPep modiaPep;
 
     private final LdapClient ldapClient;
 
@@ -43,7 +46,7 @@ public class AuthService {
     }
 
     public void sjekkTilgangTilModia() {
-        if (!veilarbPep.harVeilederTilgangTilModia(getInnloggetBrukerToken())) {
+        if (!modiaPep.harVeilederTilgangTilModia(getInnloggetBrukerToken())) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Ikke tilgang til modia");
         }
     }

--- a/src/main/java/no/nav/veilarbveileder/utils/ModiaPep.java
+++ b/src/main/java/no/nav/veilarbveileder/utils/ModiaPep.java
@@ -1,0 +1,77 @@
+package no.nav.veilarbveileder.utils;
+
+import no.nav.common.abac.AbacClient;
+import no.nav.common.abac.Pep;
+import no.nav.common.abac.domain.request.ActionId;
+import no.nav.common.types.identer.EksternBrukerId;
+import no.nav.common.types.identer.EnhetId;
+import no.nav.common.types.identer.NavIdent;
+import org.apache.commons.lang3.NotImplementedException;
+
+/**
+ * Midlertidig Pep implementasjon for å bruke "modia"-domenet i ABAC som ikke er tilgjengelig på samme URL som "veilarb"-domenet når man tar i bruk ABAC på NAIS.
+ * TODO: En litt bedre løsning er at dette løses i common og at {@link #harVeilederTilgangTilModia} flyttes til egen pep
+ */
+public class ModiaPep implements Pep {
+
+    private final Pep pep;
+
+    public ModiaPep(Pep pep) {
+        this.pep = pep;
+    }
+
+    @Override
+    public boolean harVeilederTilgangTilEnhet(NavIdent navIdent, EnhetId enhetId) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harTilgangTilEnhet(String s, EnhetId enhetId) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harTilgangTilEnhetMedSperre(String s, EnhetId enhetId) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harVeilederTilgangTilPerson(NavIdent navIdent, ActionId actionId, EksternBrukerId eksternBrukerId) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harTilgangTilPerson(String s, ActionId actionId, EksternBrukerId eksternBrukerId) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harTilgangTilOppfolging(String s) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harVeilederTilgangTilModia(String s) {
+        return pep.harVeilederTilgangTilModia(s);
+    }
+
+    @Override
+    public boolean harVeilederTilgangTilKode6(NavIdent navIdent) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harVeilederTilgangTilKode7(NavIdent navIdent) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public boolean harVeilederTilgangTilEgenAnsatt(NavIdent navIdent) {
+        throw new NotImplementedException("Not available for ABAC modia");
+    }
+
+    @Override
+    public AbacClient getAbacClient() {
+        return pep.getAbacClient();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,8 @@ app.env.openAmRefreshUrl=${VEILARBLOGIN_OPENAM_REFRESH_URL}
 app.env.aadDiscoveryUrl=${AAD_DISCOVERY_URL}
 app.env.veilarbloginAadClientId=${VEILARBLOGIN_AAD_CLIENT_ID}
 app.env.naisStsDiscoveryUrl=${SECURITY_TOKEN_SERVICE_DISCOVERY_URL}
-app.env.abacUrl=${ABAC_PDP_ENDPOINT_URL}
+app.env.abacVeilarbUrl=${ABAC_PDP_ENDPOINT_URL}
+app.env.abacModiaUrl=${ABAC_MODIA_URL}
 app.env.norg2Url=${NORG2_URL}
 app.env.unleashUrl=${UNLEASH_API_URL}
 

--- a/src/test/java/no/nav/veilarbveileder/config/ApplicationTestConfig.java
+++ b/src/test/java/no/nav/veilarbveileder/config/ApplicationTestConfig.java
@@ -1,11 +1,12 @@
 package no.nav.veilarbveileder.config;
 
 import no.nav.common.abac.AbacClient;
-import no.nav.common.abac.Pep;
+import no.nav.common.abac.VeilarbPep;
 import no.nav.common.health.HealthCheck;
 import no.nav.common.health.HealthCheckResult;
 import no.nav.veilarbveileder.mock.AbacClientMock;
-import no.nav.veilarbveileder.mock.PepMock;
+import no.nav.veilarbveileder.mock.VeilarbPepMock;
+import no.nav.veilarbveileder.utils.ModiaPep;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,8 +31,13 @@ public class ApplicationTestConfig {
     }
 
     @Bean
-    public Pep veilarbPep(AbacClient abacClient) {
-        return new PepMock(abacClient);
+    public VeilarbPep veilarbPep(AbacClient abacClient) {
+        return new VeilarbPepMock(abacClient);
+    }
+
+    @Bean
+    public ModiaPep modiapep(AbacClient abacClient) {
+        return new ModiaPep(new VeilarbPepMock(abacClient));
     }
 
     @Bean(VIRKSOMHET_ENHET_HEALTH_CHECK)

--- a/src/test/java/no/nav/veilarbveileder/mock/VeilarbPepMock.java
+++ b/src/test/java/no/nav/veilarbveileder/mock/VeilarbPepMock.java
@@ -1,20 +1,20 @@
 package no.nav.veilarbveileder.mock;
 
 import no.nav.common.abac.AbacClient;
-import no.nav.common.abac.Pep;
+import no.nav.common.abac.VeilarbPep;
 import no.nav.common.abac.domain.request.ActionId;
 import no.nav.common.types.identer.EksternBrukerId;
 import no.nav.common.types.identer.EnhetId;
 import no.nav.common.types.identer.NavIdent;
 
-public class PepMock implements Pep {
+public class VeilarbPepMock extends VeilarbPep {
 
     private final AbacClient abacClient;
 
-    public PepMock(AbacClient abacClient) {
+    public VeilarbPepMock(AbacClient abacClient) {
+        super(null, null, null, null);
         this.abacClient = abacClient;
     }
-
 
     @Override
     public boolean harVeilederTilgangTilEnhet(NavIdent navIdent, EnhetId enhetId) {


### PR DESCRIPTION
Etter ABAC gikk over til NAIS så har de splittet ut domenene slik at vi ikke kan bruke både "veilarb" og "modia" på samme URL