### PR TITLE
Confer opp inbound rules for mulighetsrommet-api

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -69,6 +69,9 @@ spec:
         - application: veilarbvedtaksstotte
           namespace: pto
           cluster: dev-fss
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: dev-gcp
   envFrom:
     - configmap: pto-config
   env:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -66,6 +66,9 @@ spec:
         - application: veilarbvedtaksstotte
           namespace: pto
           cluster: prod-fss
+        - application: mulighetsrommet-api
+          namespace: team-mulighetsrommet
+          cluster: prod-gcp
   envFrom:
     - configmap: pto-config
   env:


### PR DESCRIPTION
Mulighetsrommet/Team valp ønsker å hente veilederinformasjon. Trenger derfor lov til å kalle api'et i denne løsningen.