### PR TITLE
Gi alle AzureAD-brukere tilgang i dev

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -45,6 +45,7 @@ spec:
         mountPath: /var/run/secrets/nais.io/vault
   azure:
     application:
+      allowAllUsers: true
       enabled: true
       claims:
         extra:


### PR DESCRIPTION
Ref. endring i default brukertilganger for AzureAD, som annonsert i #nais-announcements: https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619