### PR TITLE
Kommenterer ut isAlivesjekk mot norg2 frem til vi går over til gcp

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -94,4 +94,4 @@ spec:
     - name: POAO_TILGANG_SCOPE
       value: api://dev-fss.poao.poao-tilgang/.default
     - name: NORG2_URL
-      value: https://norg2.intern.dev.nav.no/norg2
+      value: https://app-q1.adeo.no/norg2

--- a/src/main/java/no/nav/veilarbveileder/config/HealthCheckConfig.java
+++ b/src/main/java/no/nav/veilarbveileder/config/HealthCheckConfig.java
@@ -24,7 +24,7 @@ public class HealthCheckConfig {
             AxsysClient axsysClient
     ) {
         List<SelfTestCheck> selfTestChecks = Arrays.asList(
-                new SelfTestCheck("Ping mot norg2 REST API", true, norg2Client),
+              //  new SelfTestCheck("Ping mot norg2 REST API", true, norg2Client),
                 new SelfTestCheck("Ping mot NOM", true, nomClient),
                 new SelfTestCheck("Ping mot Axsys", true, axsysClient)
         );


### PR DESCRIPTION
* Etter at norg2 har gått over i gcp ser det ut til at de proxier "normale" kall helt fint, men ikke "isAlive"
* Støyende alarmer hos OPS gjør at vi bør gjøre en endring raskt, men siden vi bruker norg2client fra java-modules gjør det at det er begrenset med "egen definert"-url akkurat for å treffe isAliveendepunktet til norg2 i denne overgangsperioden
* Vi skal snart gå over til gcp så vi kan heller da gå mot gcpurlen til norg2 og igjen legge ved isAlivesjekken i vår healthcheck