### PR TITLE
Sette loggdestinasjonar eksplisitt

### DIFF
--- a/.nais/application/application-config-dev-gcp.yaml
+++ b/.nais/application/application-config-dev-gcp.yaml
@@ -9,6 +9,11 @@ spec:
   image: {{image}}
   port: 8080
   webproxy: true
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   liveness:

--- a/.nais/application/application-config-prod-gcp.yaml
+++ b/.nais/application/application-config-prod-gcp.yaml
@@ -9,6 +9,11 @@ spec:
   image: {{image}}
   port: 8080
   webproxy: true
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   liveness:


### PR DESCRIPTION
[Nais skal/har gått over til Grafana Loki som default loggverktøy og Elastic Kibana er difor deprekert](https://nav-it.slack.com/docs/T5LNAMWNA/F08RNSRJ934). Elastic vil vere tilgjengeleg ut året, så inntil vi får migrert til Grafana Loki, må vi eksplisitt spesifisere Elastic Kibana som loggdestinasjon. Legg difor til både `elastic` og `loki` som loggdestinasjonar slik at vi kan halde fram med å få loggar i Kibana. Når vi er blitt vande nok med Loki kan vi gå over permanent og fjerne `elastic`.